### PR TITLE
Make SVG board images work again

### DIFF
--- a/pygn_handler.py
+++ b/pygn_handler.py
@@ -99,7 +99,13 @@ if __name__ == '__main__':
 
 
     while True:
-        input_str = sys.stdin.read()
+        input_str = sys.stdin.readline()
+        if len(input_str) == 0:
+            # eof
+            break
+        if len(input_str) == 1:
+            # just newline
+            continue
         p = re.compile("([0-9]+) --")
         m = p.search(input_str)
 
@@ -109,6 +115,8 @@ if __name__ == '__main__':
 
         code = m.group(1) # Command code for handling input.
         pgn = input_str[input_str.index(m.group(0)) + len(m.group(0)):].strip()
+        pgn = re.sub(r'\\n', '\n', pgn)
+        pgn = pgn + '\n\n'
 
         game = chess.pgn.read_game(io.StringIO(pgn))
         board = game.board()


### PR DESCRIPTION
This works by reorienting server input/output around strictly newline-delimited messages.

* remove `(string 4)` (EOF) from server-send messages
* erase buffer _before_ accepting input (also allows removing a temp variable)
* watch for newline `(eq ?\n (char-before (point-max)))` instead of first change in `buffer-size`
* compress PGN messages onto single line by escaping newlines
* unescape newlines after receipt in the Python server
* convert the server to use `readline()` rather than `read()`, since messages must be a full line
* break from the server loop if an EOF is received (but we no longer send EOF)
* ignore empty lines sent to the server (might easily happen if two trailing newlines were added on the elisp end)