### PR TITLE
Fix SVG rendering

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -103,6 +103,7 @@
 
 (require 'cl-lib)
 (require 'nav-flash nil t)
+(require 'svg)
 
 (autoload 'image-toggle-display-text  "image-mode" "Show the image file as text."      nil)
 (autoload 'image-toggle-display-image "image-mode" "Show the image of the image file." nil)
@@ -761,16 +762,14 @@ When called non-interactively, display the board corresponding to POS."
 
 When called non-interactively, display the board corresponding to POS."
   (interactive "d")
-  (let* ((svg (pygn-mode-board-at-pos pos))
+  (let* ((svg-data (pygn-mode-board-at-pos pos))
          (buf (get-buffer-create " *pygn-mode-board*"))
          (win (get-buffer-window buf)))
     (with-current-buffer buf
       (when (eq major-mode 'image-mode)
         (image-toggle-display-text))
       (delete-region (point-min) (point-max))
-      (insert svg)
-      (setq major-mode 'image-mode)
-      (image-toggle-display-image))
+      (insert-image (create-image svg-data 'svg t)))
     (display-buffer buf '(display-buffer-reuse-window))
     (unless win
       (setq win (get-buffer-window buf))


### PR DESCRIPTION
This change fixes SVG rendering for me. 

Requires `svg` (not sure what the earliest emacs version it's included in). 

Mergest into `RW/repair-svg-boards`