### PR TITLE
Remove SVG

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -128,7 +128,6 @@
 
 (require 'cl-lib)
 (require 'nav-flash nil t)
-(require 'svg)
 
 (autoload 'image-toggle-display-text  "image-mode" "Show the image file as text."      nil)
 (autoload 'image-toggle-display-image "image-mode" "Show the image of the image file." nil)


### PR DESCRIPTION
No idea what I was thinking, but when I wrote the code I knew it wasn't using SVG, yet still `require`'d it and PR'd it like it was a dependency. Not actually used. 