### PR TITLE
Refactor server interface

### DIFF
--- a/pygn_server.py
+++ b/pygn_server.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python
 #
-# pgn_to_fen
+# pygn_server
 #
-# return the FEN after the last move in a PGN input file
+# driver for Emacs mode pygn-mode.el
 #
 # notes
 #
 #     requires python-chess
+#
+#     server request format
+#
+#         <command> <options> -- <data>
+#
+#     where
+#
+#         * <command> begins with ":"
+#         * <options> are CLI-like, as accepted by argparse
+#         * double-dash is mandatory
+#         * <data> is usually a PGN with newlines escaped to "\n"
+#
+#     server example request
+#
+#         :board -pixels=200 -- [Event "?"]\n[Site ...
 #
 # bugs
 #


### PR DESCRIPTION
What do you think about this cleanup?

* move relevant defuns together
* in function names, vars, and docstrings, refer to "server" instead of variants of "python process"
* rename `pygn_handler.py` to `pygn_server.py`
* hoist response wait and timeout to variables.  We shouldn't have to be passing these every time.  And key values are also buried in code.
* many docstring revisions
* remove TODO comment which is completed
* no need to restart server in `pygn-mode-fen-at-pos` and `pygn-mode-board-at-pos`, since it gets restarted later by the query function
* guard form when checking for running server
* use `unless` instead of `(when (not …`
