### PR TITLE
Better newline and EOF handling on both server and client sides

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -326,6 +326,7 @@
 (defun pygn-mode--kill-process ()
   "Stop the currently running `pygn-mode--python-process' if it is running."
   (when (pygn-mode--process-running-p)
+    (process-send-eof pygn-mode--python-process)
     (delete-process pygn-mode--python-process)
     (setq pygn-mode--python-process nil)
     (message "pygn-mode Python service killed.")))
@@ -333,7 +334,9 @@
 (defun pygn-mode--send-process (message)
   "Send MESSAGE to the running `pygn-mode--python-process'."
   (if (pygn-mode--process-running-p)
-      (process-send-string pygn-mode--python-process (concat message (string 10)))
+      (process-send-string
+       pygn-mode--python-process
+       (replace-regexp-in-string "[\n\r]*$" "\n" message))
     (error "Need running Python process to send pygn-mode message")))
 
 (defun pygn-mode--receive-process (seconds &optional max-time)

--- a/pygn_handler.py
+++ b/pygn_handler.py
@@ -55,13 +55,12 @@ def listen():
     while True:
         input_str = sys.stdin.readline()
 
+        # TODO: test readline and empty-line handling on Windows
         # Handle terminating characters and garbage.
-        # TODO: make more safe.
         if len(input_str) == 0:
             # eof
             break
-        if len(input_str) == 1:
-            # just newline
+        if input_str == '\n':
             continue
 
         # Parse request.


### PR DESCRIPTION
* explicitly check for empty newline in server
* ensure that ordinary messages have exactly one newline
* send EOF before killing process (may as well get clean exit)
* note that line terminators may be different on Windows