### PR TITLE
Font-lock microoptimization: single-line tagpair values

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -593,7 +593,7 @@ Intended to be used as a `syntax-propertize-function'."
  'pygn-mode
  '(
    ;; tagpair keys. values are handled by the syntax table
-   ("^\\[\\(\\S-+\\)\\s-+\".*\"\\]" 1 'pygn-mode-tagpair-key-face)
+   ("^\\[\\(\\S-+\\)\\s-+\"[^\n]*\"\\]" 1 'pygn-mode-tagpair-key-face)
    ;; tagpair open-brackets
    ("^\\[" . 'pygn-mode-tagpair-bracket-face)
    ;; tagpair close-brackets


### PR DESCRIPTION
Slightly faster, and more correct.