### PR TITLE
Version every server request and response

### DIFF
--- a/doc/examples/example_request.txt
+++ b/doc/examples/example_request.txt
@@ -1,1 +1,1 @@
-:pgn-to-fen -- :pgn [Event "?"]\n[Site "?"]\n[Date "????.??.??"]\n[Round "?"]\n[White "?"]\n[Black "?"]\n[Result "*"]\n[SetUp "1"]\n[FEN "r1bR2Q1/ppp3pp/4p1k1/2b1P1n1/1np1q3/5N2/PPP3PP/5R1K w - - 2 18"]\n\n18. Qe8+ Kh6 19. Nxg5 Kxg5\n\n
+:version 0.5.0 :pgn-to-fen -- :pgn [Event "?"]\n[Site "?"]\n[Date "????.??.??"]\n[Round "?"]\n[White "?"]\n[Black "?"]\n[Result "*"]\n[SetUp "1"]\n[FEN "r1bR2Q1/ppp3pp/4p1k1/2b1P1n1/1np1q3/5N2/PPP3PP/5R1K w - - 2 18"]\n\n18. Qe8+ Kh6 19. Nxg5 Kxg5\n\n

--- a/doc/server.md
+++ b/doc/server.md
@@ -25,7 +25,7 @@ Requests to the `pygn_server.py` server are on a single line, terminated by
 newline, in the form
 
 ```
-<command> [<options>] -- <payload-type> <payload-data>
+:version <version> <command> [<options>] -- <payload-type> <payload-data>
 ```
 
 Note that `<options>` are not required, but a single double-dash `--` is
@@ -34,8 +34,13 @@ mandatory.
 Example:
 
 ```
-:pgn-to-board -pixels=200 -- :pgn [Event "?"]\n[Site ...
+:version 0.5.0 :pgn-to-board -pixels=200 -- :pgn [Event "?"]\n[Site ...
 ```
+
+### `<version>`
+
+The request `<version>` string must agree between the client and server.  If
+the version string does not agree, the server may refuse to respond.
 
 ### `<command>`
 
@@ -93,14 +98,20 @@ Responses from the `pygn_server.py` server are on a single line, terminated by
 newline, in the form
 
 ```
-<payload-type> <payload-data>
+:version <version> <payload-type> <payload-data>
 ```
 
 Example:
 
 ```
-:fen r1bRQ3/ppp3pp/4p3/2b1P1k1/1np1q3/8/PPP3PP/5R1K w - - 0 20
+:version 0.5.0 :fen r1bRQ3/ppp3pp/4p3/2b1P1k1/1np1q3/8/PPP3PP/5R1K w - - 0 20
 ```
+
+### `<version>`
+
+The response `<version>` string must agree between the client and server.  If
+the version string does not agree, the client may attempt to restart the
+server.
 
 ### `<payload-type>`
 


### PR DESCRIPTION
This addresses an immediate bug by keeping the server from getting into a permanent bad state when generating a board from the location of a result code.

It also enables upgrades to occur without restarting Emacs -- with the hiccup of a single request failing.

As noted in a comment, it is a little dirty that the parser is permitted to selectively restart the server.