### PR TITLE
Support semicolon comments to end-of-line

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -252,6 +252,8 @@
     (with-syntax-table st
       (modify-syntax-entry ?{ "<")
       (modify-syntax-entry ?} ">")
+      (modify-syntax-entry ?\; "< b")
+      (modify-syntax-entry ?\n "> b")
       (modify-syntax-entry ?\\ "\\")
       (modify-syntax-entry ?\" "\"")
       (modify-syntax-entry ?| "w")


### PR DESCRIPTION
http://www.saremba.de/chessgml/standards/pgn/pgn-complete.htm#c5

~For some reason I had `%` instead.~

Now supports both percent `%` in the first position, and semicolon `;` in any position, to introduce comments which run to the end of the line.