### PR TITLE
Make all actions inclusive of move under point + major refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+EMACS := emacs
+
+EMACS_CLEAN := -Q
+EMACS_BATCH := $(EMACS_CLEAN) --batch
+WORK_DIR := $(shell pwd)
+PACKAGE_NAME := $(shell basename $(WORK_DIR))
+AUTOLOADS_FILE := $(PACKAGE_NAME)-autoloads.el
+
+TEST_DIR := ert-tests
+# TESTS can be overridden to specify a subset of tests
+TESTS=
+
+.PHONY : build autoloads test-autoloads test-tests test-prep test-batch test clean
+
+build :
+	$(EMACS) $(EMACS_BATCH) --eval             \
+	    "(progn                                \
+	      (setq byte-compile-error-on-warn t)  \
+	      (batch-byte-compile))" *.el
+
+autoloads :
+	$(EMACS) $(EMACS_BATCH) --eval                       \
+	    "(progn                                          \
+	      (setq generated-autoload-file \"$(WORK_DIR)/$(AUTOLOADS_FILE)\") \
+	      (update-directory-autoloads \"$(WORK_DIR)\"))"
+
+test-autoloads : autoloads
+	@$(EMACS) $(EMACS_BATCH) -L . -l './$(AUTOLOADS_FILE)' || \
+	 ( echo "failed to load autoloads: $(AUTOLOADS_FILE)" && false )
+
+test-tests :
+	@perl -ne 'if (m/^\s*\(\s*ert-deftest\s*(\S+)/) {die "$$1 test name duplicated in $$ARGV\n" if $$dupes{$$1}++}' '$(TEST_DIR)/'*-test.el
+
+test-prep : build test-autoloads test-tests
+
+test-batch :
+	@cd '$(TEST_DIR)'                                 && \
+	(for test_lib in *-test.el; do                       \
+	   $(EMACS) $(EMACS_BATCH) -L . -L ..                \
+	   -l "$$test_lib" --eval                            \
+	    "(progn                                          \
+	      (fset 'ert--print-backtrace 'ignore)           \
+	      (ert-run-tests-batch-and-exit '(and \"$(TESTS)\" (not (tag :interactive)))))" || exit 1; \
+	done)
+
+test : test-prep test-batch
+
+clean :
+	@rm -f '$(AUTOLOADS_FILE)' *.elc *~ */*.elc */*~ .DS_Store */.DS_Store *.bak */*.bak

--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ form.
 Default mouse bindings are provided:
 
  * mouse-2 — `pygn-mode-mouse-display-variation-board`
- * double-mouse-2 — `pygn-mode-mouse-display-variation-board-inclusive`
 
 In English, clicking the middle mouse button on a move in Emacs displays a
-board image computed before that move was made.  Double-clicking the mouse
-button on a move displays a board after that move was made.
+board image computed after that move was made.
 
 In addition, the mouse wheel (buttons 4/5) is bound to `pygn-mode-next-move`
 and `pygn-mode-previous-move` when hovering over the `PyGN` lighter in the

--- a/ert-tests/pygn-mode-test.el
+++ b/ert-tests/pygn-mode-test.el
@@ -1,0 +1,39 @@
+;; -*- lexical-binding: t -*-
+
+(require 'pygn-mode)
+
+(setq pygn-mode-test-containing-directory
+      (file-name-directory
+       (or load-file-name
+           (bound-and-true-p byte-compile-current-file)
+           (buffer-file-name (current-buffer)))))
+
+(setq pygn-mode-test-input-directory
+      (expand-file-name "test-input" pygn-mode-test-containing-directory))
+
+(setq pygn-mode-test-output-directory
+      (expand-file-name "test-output" pygn-mode-test-containing-directory))
+
+;;; pygn-mode-pgn-at-pos
+
+;; todo: Ideally, PGN-at-pos tests would cover every position in this and
+;; several other input files. How to organize that with clarity not clutter?
+(ert-deftest pygn-mode-pgn-at-pos-01 nil
+  (with-temp-buffer
+    (insert-file-contents-literally
+     (expand-file-name "test-01.pgn" pygn-mode-test-input-directory))
+    (goto-char (point-min))
+  (should (equal
+           "[Event \"?\"]\n"
+           (pygn-mode-pgn-at-pos (point))))))
+
+;;
+;; Emacs
+;;
+;; Local Variables:
+;; coding: utf-8
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+;;
+
+;;; pygn-mode-test.el ends here

--- a/ert-tests/test-input/test-01.pgn
+++ b/ert-tests/test-input/test-01.pgn
@@ -1,0 +1,20 @@
+[Event "?"]
+[Site "?"]
+[Date "????.??.??"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "r1bR2Q1/ppp3pp/4p1k1/2b1P1n1/1np1q3/5N2/PPP3PP/5R1K w - - 2 18"]
+
+18. Qe8+ Kh6 ({+6.30} 18... Nf7 19. Rxc8 Qc6 20. Rxa8 Qxe8 21. Rxe8 Kh5 22. Rd1
+Ng5 23. Rd7 +−) 19. Nxg5 Kxg5 ({+7.74} 19... Bd7 20. Nxe4 Bxe8 21. Rxa8 Bc6 22.
+Nxc5 b6 23. Rxa7 bxc5 24. Rxc7 +−) ({+8.70} 19... Qg4 20. Nf7+ Kh5 21. Rf3 c3
+22. bxc3 Nc6 23. Qh8 h6 24. Rg8 +−) 20. Qf7 Qg6 ({0.00} 20... Nc6 21. Qxg7+ Qg6
+22. Rg8 Qxg7 23. Rxg7+ Kh6 24. Rff7 Nxe5 25. Rxh7+ =) ({0.00} 20... Kh6 21. Rg8
+Qxe5 22. Rf3 Qe1+ 23. Rf1 Qe5 =) 21. Rg8 Qxf7 ({0.00} 21... Kh5 22. Qf3+ Kh6 23.
+Qf4+ Qg5 24. Qxg5+ Kxg5 25. Rxg7+ Kh6 26. Rxc7 =) ({0.00} 21... Kh6 22. Qf4+ Qg5
+23. Qxg5+ Kxg5 24. Rxg7+ Kh6 25. Rxc7 Be3 26. Rf6+ =) 22. Rxf7 g6 ({0.00} 22...
+Kh6 23. Rgxg7 Be3 24. Rxh7+ Kg5 25. Rhg7+ Kh5 26. Rh7+ Kg4 27. Rhg7+ =) ({0.00}
+22... b6 23. Rgxg7+ Kh6 24. Rxh7+ Kg5 25. Rhg7+ Kh5 26. Rh7+ Kg5 =) *


### PR DESCRIPTION
The point of the refactor is to pass PGN data instead of positions to inner functions.  The refactor could probably be taken further as noted inline.  `pygn-mode-pgn-at-pos` was created, which explicitly covers a lot of cases WRT the position of the point, and accomplishes the functional change, by always being inclusive of the move.

In addition:
* removed defunct "inclusive" defuns and bindings + doc
* stubbed a test suite mainly intended for for `pygn-mode-pgn-at-pos`
* added a Makefile with a `make test` batch target
* delinted so that `make build` would complete with `byte-compile-error-on-warn` set to t (only real issue was missing forward declaration of `nav-flash-delay`)
* also fixed outdated call to `pygn-mode-display-variation-gui-board-at-point` to get `make build` to pass
* updated syntax table so that result codes and suffix annotations are recognized as word characters
* created several more context-recognition defuns such as `pygn-mode-inside-header-p`
* corrected `pygn-mode-inside-variation-p` so that it isn't confused by header tagpairs
* split the looking-at-legal-move defun into two variants: relaxed/strict
* created a looking-back-legal-move defun
* fall back to calling `pygn-mode-pgn-at-pos` from `pygn-mode-inside-variation-p` unless inside variation.  update move-boundary logic in `pygn-mode-inside-variation-p`.
* `pygn-mode--send-pgn-and-fetch` does nothing if we are passing PGN data instead of position.  removed.
* updated various places to pass PGN data instead of positions
* simplify defuns such as `pygn-mode-mouse-display-variation-board-inclusive` which did some of the work now tucked away in `pygn-mode-pgn-at-pos`/`pygn-mode-pgn-at-pos-as-if-variation`
* comments: remove some todos which were already finished, and add some new ones