### PR TITLE
Use Python f-strings

### DIFF
--- a/pygn_server.py
+++ b/pygn_server.py
@@ -8,7 +8,7 @@
 #
 #     requires python-chess
 #
-#     documentation of the server request format is at doc/server.md
+#     documentation of the server protocol is at doc/server.md
 #
 # bugs
 #
@@ -143,9 +143,9 @@ def listen():
             print("Bad request options: {}".format(req_options), file=sys.stderr)
             continue
 
-        # Payload_type is for future extensibility, currently always :pgn
         if not req_payload_type == ":pgn":
             print("Bad request :payload-type (unknown): {}".format(req_payload_type), file=sys.stderr)
+        # :payload-type is for future extensibility, currently always :pgn
             continue
 
         # Build game board.


### PR DESCRIPTION
Since Python 3.6 is to be required in #123, we might as use f-strings for tidier string handling.

Includes some comment and errmsg tweaks.  Single-quotes preferred over double-quotes for consistency.