### PR TITLE
Check for buffer existence

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1055,9 +1055,10 @@ will respect variations."
         (pygn-mode-follow-mode-post-command-hook)
         (add-hook 'post-command-hook #'pygn-mode-follow-mode-post-command-hook nil t))
     (remove-hook 'post-command-hook #'pygn-mode-follow-mode-post-command-hook t)
-    (let ((win (get-buffer-window (get-buffer pygn-mode-board-buffer-name))))
-      (when (window-live-p win)
-        (delete-window win)))))
+    (when (get-buffer pygn-mode-board-buffer-name)
+      (let ((win (get-buffer-window (get-buffer pygn-mode-board-buffer-name))))
+        (when (window-live-p win)
+          (delete-window win))))))
 
 (defun pygn-mode-follow-mode-post-command-hook ()
   "Driver for `pygn-mode-follow-minor-mode'.


### PR DESCRIPTION
I was experiencing the following error (`delete-window` error below)
```lisp
buffer... (get-buffer pygn-mode-board-buffer-name): nil
window... (get-buffer-window (get-buffer pygn-mode-board-buffer-name)): #<window 7 on wild-starting-in-middle-game.pgn>
delete-window: Attempt to delete minibuffer or sole ordinary window
```
I [attached prints here](https://github.com/dwcoates/pygn-mode/blob/DC/properly-check-for-board-buffer-to-kill/pygn-mode.el#L1058) to demonstrate above that a `nil` result from `get-buffer` does not imply a `nil` result from `get-buffer-window`)