### PR TITLE
Update dates and bump version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2019, Roland Walker, Dodge Coates
+Copyright (c) 2019-2021, Roland Walker, Dodge Coates
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1,12 +1,12 @@
 ;;; pygn-mode.el --- Major-mode for chess PGN files, powered by Python -*- lexical-binding: t -*-
 ;;
-;; Copyright (c) 2019 Dodge Coates and Roland Walker
+;; Copyright (c) 2019-2021 Dodge Coates and Roland Walker
 ;;
 ;; Author: Dodge Coates and Roland Walker
 ;; Homepage: https://github.com/dwcoates/pygn-mode
 ;; URL: https://raw.githubusercontent.com/dwcoates/pygn-mode/master/pygn-mode.el
-;; Version: 0.5.0
-;; Last-Updated: 26 Nov 2019
+;; Version: 0.5.1
+;; Last-Updated: 18 Jun 2021
 ;; Package-Requires: ((emacs "25.1") (uci-mode "0.5.0") (nav-flash "1.0.0") (ivy "0.10.0"))
 ;; Keywords: data, games, chess
 ;;
@@ -129,7 +129,7 @@
 ;;; Code:
 ;;
 
-(defconst pygn-mode-version "0.5.0")
+(defconst pygn-mode-version "0.5.1")
 
 ;;; Imports
 

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://raw.githubusercontent.com/dwcoates/pygn-mode/master/pygn-mode.el
 ;; Version: 0.5.1
 ;; Last-Updated: 18 Jun 2021
-;; Package-Requires: ((emacs "25.1") (uci-mode "0.5.0") (nav-flash "1.0.0") (ivy "0.10.0"))
+;; Package-Requires: ((emacs "25.1") (uci-mode "0.5.4") (nav-flash "1.0.0") (ivy "0.10.0"))
 ;; Keywords: data, games, chess
 ;;
 ;; Simplified BSD License

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -39,7 +39,7 @@
 ;;
 ;; Customization
 ;;
-;;     M-x customize-group RET pygn-mode RET
+;;     M-x customize-group RET pygn RET
 ;;
 ;; See Also
 ;;

--- a/pygn_server.py
+++ b/pygn_server.py
@@ -19,7 +19,7 @@
 ### version
 ###
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 ###
 ### imports


### PR DESCRIPTION
* update dates and bump version to 0.5.1
* require latest uci-mode
* fix doc referring to outdated customize group (missed in #143)

Preparing for MELPA release.