### PR TITLE
Replace native font-lock with tree-sitter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     paths-ignore:
-    - '**.md'
-    - '**.py'
-    - '**.png'
-    - '**.gif'
+      - '**.md'
+      - '**.py'
+      - '**.png'
+      - '**.gif'
 
 jobs:
   build:
@@ -14,14 +14,19 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.3
           - 26.3
           - 27.2
     steps:
-    - uses: purcell/setup-emacs@master
-      with:
-        version: ${{ matrix.emacs_version }}
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
 
-    - uses: actions/checkout@v2
-    - name: Run tests
-      run: 'make test'
+      - uses: conao3/setup-cask@master
+        with:
+          version: 'snapshot'
+
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: |
+          "$HOME/.cask/bin/cask" install
+          make test CASK="$HOME/.cask/bin/cask"

--- a/Cask
+++ b/Cask
@@ -1,0 +1,4 @@
+(source gnu)
+(source melpa)
+
+(package-file "pygn-mode.el")

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-EMACS := emacs
+ifneq ($(CASK),)
+ EMACS := $(CASK) emacs
+else
+ EMACS := emacs
+endif
 
 EMACS_CLEAN := -Q
 EMACS_BATCH := $(EMACS_CLEAN) --batch
@@ -34,14 +38,13 @@ test-tests :
 test-prep : build test-autoloads test-tests
 
 test-batch :
-	@cd '$(TEST_DIR)'                                 && \
-	(for test_lib in *-test.el; do                       \
-	   $(EMACS) $(EMACS_BATCH) -L . -L ..                \
-	   -l "$$test_lib" --eval                            \
-	    "(progn                                          \
-	      (fset 'ert--print-backtrace 'ignore)           \
-	      (ert-run-tests-batch-and-exit '(and \"$(TESTS)\" (not (tag :interactive)))))" || exit 1; \
-	done)
+	for test_lib in $(TEST_DIR)/*-test.el; do           \
+	  $(EMACS) $(EMACS_BATCH) -L $(TEST_DIR) -L .       \
+	  -l "$$test_lib" --eval                            \
+	   "(progn                                          \
+	     (fset 'ert--print-backtrace 'ignore)           \
+	     (ert-run-tests-batch-and-exit '(and \"$(TESTS)\" (not (tag :interactive)))))" || exit 1; \
+	done
 
 test : test-prep test-batch
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An Emacs major-mode for chess PGN files, powered by Python.
 
 Provides
 
- * syntax highlighting via `font-lock`, including highlighting of bracketed
+ * syntax highlighting via [tree-sitter](https://github.com/emacs-tree-sitter), including highlighting of bracketed
    `{comments}` and parenthesized `(variations)`.
  * customizable faces
  * navigation and selection commands
@@ -146,7 +146,9 @@ emacs-chess
 
 ## Compatibility and Requirements
 
-GNU Emacs 25.1+
+GNU Emacs 26.1+, compiled with dynamic module support
+
+[tree-sitter.el](https://github.com/emacs-tree-sitter/elisp-tree-sitter) and [tree-sitter-langs.el](https://github.com/emacs-tree-sitter/tree-sitter-langs)
 
 Python 3.7+
 

--- a/pygn_server.py
+++ b/pygn_server.py
@@ -19,7 +19,7 @@
 ### version
 ###
 
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
 ###
 ### imports


### PR DESCRIPTION
After https://github.com/emacs-tree-sitter/tree-sitter-langs/pull/18 we can use tree-sitter instead of native font lock for syntax highlighting.

This simplifies the code: we no longer need various font-lock helper functions.  The performance issues of `pygn-mode-after-change-function` are no longer an issue, since it can be removed.

Tree-sitter also gives us _much_ more correct syntax highlighting: https://github.com/dwcoates/pygn-mode/blob/master/ert-tests/test-input/test-02.pgn is now marked up correctly.  Bracketed inline comments may now contain close-parenthesis characters.  Recursive variations are now supported.

There is one breaking change: `pygn-mode-nag-face` was renamed `pygn-mode-annotation-face`.  An obsolete-face-alias is provided. Otherwise, twelve new faces are added.  The new faces default to matching existing faces, so the overall look does not change unless the user decides to customize.  An example is that move numbers may now be highlighted differently than moves.

I would like to add another face for second-level-and-below recursive variations, but could not get the tree-sitter query correct.  It may be that the easiest way to do that is to make a change in the tree-sitter grammar.

Tree-sitter is now a hard dependency, as is Emacs 26.1+, compiled with dynamic module support.

Testing shows that tree-sitter is performant, even for large, complex files.

It may also be that we can ultimately remove certain syntax-table settings, but we need to keep them for now as they affect navigation.

This PR is ready for review, ~~but I would like to do a few more tests before merging.  It hasn't yet been run in a fresh Emacs.~~ done

The next steps after this are to use tree-sitter's syntax tree for more accurate navigation, which I believe can be done without changing interfaces.

Edit: a `Cask` file is introduced to handle installing dependencies for CI.