### PR TITLE
Port pygn-mode-previous-move to tree-sitter

### DIFF
--- a/ert-tests/pygn-mode-test.el
+++ b/ert-tests/pygn-mode-test.el
@@ -48,6 +48,29 @@
     (pygn-mode-next-move)
     (should (= (point) 186))))
 
+;;; pygn-mode-previous-move
+
+(ert-deftest pygn-mode-previous-move-01 nil
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name "test-01.pgn" pygn-mode-test-input-directory))
+    (pygn-mode)
+    (goto-char (point-min))
+    (pygn-mode-next-move)
+    (pygn-mode-next-move)
+    (pygn-mode-previous-move)
+    (should (= (point) 181))
+    (should (looking-at-p "Qe8\\+\\>"))))
+
+(ert-deftest pygn-mode-previous-move-02 nil
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name "test-01.pgn" pygn-mode-test-input-directory))
+    (pygn-mode)
+    (goto-char (point-min))
+    (pygn-mode-next-move)
+    (should-error (pygn-mode-previous-move))))
+
 ;;
 ;; Emacs
 ;;


### PR DESCRIPTION
~This PR is branched off of #157 and will look like a mess until rebased.~ rebased

Similar to #163, this ports the previous-move motion command to the facilities provided by tree-sitter, removing the need for tricky regular expressions.

The motion command was made compatible with the previous function in its details.

cc @qnix 

Edits: unlike in #163 I was unable to delete `pygn-mode-backward-exit-variations-and-comments` yet because it is used elsewhere.

The `arg` to `pygn-mode-previous-move` was also made optional, to ease noninteractive use.