### PR TITLE
Add pygn-mode-describe-annotation-at-pos interactive command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ of each game starting with an `[Event "?"]` tagpair.
  * `pygn-mode-display-fen-at-pos` — display FEN in another buffer
  * `pygn-mode-display-variation-fen-at-pos` — display FEN, respecting variations
 
+### Annotation Symbol Commands
+
+ * `pygn-mode-describe-annotation-at-pos` — echo description of annotation symbol, optionally copying to clipboard
+
 ### Board Commands
 
  * `pygn-mode-display-board-at-pos` — display board image in another buffer (format automatic)

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -684,6 +684,10 @@ ignore the bundled library and use only the system `$PYTHONPATH'."
       '(menu-item "Go Depth at Point" pygn-mode-engine-go-depth
                   :enable (featurep 'uci-mode)
                   :help "UCI Engine \"go depth\" at point in separate window"))
+    (define-key map [menu-bar PyGN pygn-mode-describe-annotation-at-pos]
+      '(menu-item "Annotation at Point" pygn-mode-describe-annotation-at-pos
+                  :enable (pygn-mode--true-containing-node 'annotation)
+                  :help "Describe annotation at point in the echo area"))
     (define-key map [menu-bar PyGN pygn-mode-display-fen-at-pos]
       '(menu-item "FEN at Point" pygn-mode-display-fen-at-pos
                   :help "Display FEN at point in separate window"))
@@ -703,6 +707,7 @@ ignore the bundled library and use only the system `$PYTHONPATH'."
     ;; (define-key map (kbd "C-c C-p") 'pygn-mode-previous-game)
     ;; (define-key map (kbd "M-f")     'pygn-mode-next-move)
     ;; (define-key map (kbd "M-b")     'pygn-mode-previous-move)
+    ;; (define-key map (kbd "C-h $")   'pygn-mode-describe-annotation-at-pos)
     ;;
     ;; and note that `down-list'/`backward-up-list' already works to
     ;; enter/exit a parenthesized variation
@@ -1470,7 +1475,10 @@ otherwise.  If called from Lisp, enable mode if ARG is omitted or nil.
 
 When turned on, cursor motion in a PyGN buffer causes automatic display of
 a board representation corresponding to the point.  The displayed board
-will respect variations."
+will respect variations.
+
+In addition, if the cursor rests on an annotation symbol, the
+meaning of the symbol will be displayed in the echo area."
   :group 'pygn
   :init-value nil
   :lighter " fol"
@@ -1488,6 +1496,7 @@ will respect variations."
   "Driver for function `pygn-mode-follow-minor-mode'.
 
 Intended for use in `post-command-hook'."
+  (pygn-mode-describe-annotation-at-pos (point) nil 'no-error)
   (pygn-mode-display-variation-board-at-pos (point)))
 
 (cl-defun pygn-mode--run-diagnostic ()
@@ -1751,6 +1760,35 @@ When called non-interactively, select the game containing POS."
   (goto-char pos)
   (push-mark (pygn-mode-game-end-position) t t)
   (goto-char (pygn-mode-game-start-position)))
+
+(defun pygn-mode-describe-annotation-at-pos (pos &optional do-copy no-error)
+  "Describe the annotation symbol at point in the echo area.
+
+When called non-interactively, describe the annotation
+symbol corresponding to POS.
+
+With `prefix-arg' DO-COPY, copy the description to the kill ring,
+and to the system clipboard when running a GUI Emacs.
+
+When NO-ERROR is set, noninteractively, do not signal an error
+when POS is not on an annotation symbol."
+  (interactive "d\nP")
+  (let ((annotation-node (pygn-mode--true-containing-node 'annotation pos)))
+    (if annotation-node
+        (let* ((annotation-text (buffer-substring-no-properties
+                                 (pygn-mode--true-node-first-position annotation-node)
+                                 (pygn-mode--true-node-after-position annotation-node)))
+               (description (or (gethash annotation-text pygn-mode-annotation-names) "Unknown"))
+               (full-description (format "%s - %s" annotation-text description)))
+          (when do-copy
+            (kill-new full-description)
+            (when (and (fboundp 'gui-set-selection)
+                       (display-graphic-p))
+              (gui-set-selection 'CLIPBOARD full-description)))
+          (message "%s%s" full-description (if do-copy (propertize "\t(copied)" 'face '(:foreground "grey33")) "")))
+      ;; else
+      (unless no-error
+        (error "No annotation symbol")))))
 
 (defun pygn-mode-echo-fen-at-pos (pos &optional do-copy)
   "Display the FEN corresponding to the point in the echo area.


### PR DESCRIPTION
~This is branched off of #170, and will look like a mess until rebased.~ rebased

Add a command `pygn-mode-describe-annotation-at-pos` which, when invoked while the point is on an annotation symbol such as `$5`, sends a description to the echo area like:

```
$5 - Speculative or interesting move
```

Also:

 * add the command to GUI menu
 * add it to the functionality of `pygn-mode-follow-minor-mode`
 * add the command to suggested bindings in comments
 * add the command to `README.md`