### PR TITLE
Bugfix: always turn on pygn-mode in PGN-containing temp buffers

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1508,6 +1508,8 @@ When called non-interactively, display the FEN corresponding to POS."
     ;; todo it might be a better design if a temp buffer wasn't needed here
     (with-temp-buffer
       (insert pgn)
+      ;; todo re-running the mode seems wasteful
+      (pygn-mode)
       (pygn-mode-display-fen-at-pos (point-max)))))
 
 ;; interactive helper
@@ -1594,6 +1596,8 @@ The board display respects variations."
     ;; todo it might be a better design if a temp buffer wasn't needed here
     (with-temp-buffer
       (insert pgn)
+      ;; todo re-running the mode seems wasteful
+      (pygn-mode)
       (pygn-mode-display-board-at-pos (point)))))
 
 (defun pygn-mode-display-variation-board-at-pos (pos)


### PR DESCRIPTION
Per #173, if we create a temp buffer containing PGN data, we must turn on `pygn-mode` if we expect `pygn-mode-*` defuns to be able to work in that buffer.

Without the tree-sitter parse tree to refer to, many defuns won't work, or will throw exceptions.

We actually should have noticed this issue back in #154, when the mode was set for the temp buffer in the tests.

Secondarily, as comments note throughout, this whole approach of creating and re-parsing is probably slow, and we should work on redesigning some of these to get the same functionality without temp buffers.