### PR TITLE
Make comment-region work across arbitrary movetext positions in pygn-mode, including across lines

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -468,6 +468,28 @@ ignore the bundled library and use only the system `$PYTHONPATH'."
 
 ;;; Utility functions
 
+(defun pygn-mode-comment-region-contextually (beg end &optional arg)
+  "Wrap `comment-region-default' to remove `comment-continue' characters.
+
+This allows multi-line `comment-region' to work in `pygn-mode'
+without adding extra characters at beginning-of-line."
+  (if (and (pygn-mode--true-containing-node 'movetext beg)
+           (pygn-mode--true-containing-node 'movetext end))
+      (save-match-data
+        (comment-region-default beg end arg)
+        (save-restriction
+          (exchange-point-and-mark)
+          (narrow-to-region (min (point) (mark) beg) (max (point) (mark) end))
+          (save-excursion
+            (goto-char (point-min))
+            (while (re-search-forward (concat "^" (regexp-quote (or comment-continue "|"))) nil t)
+              (replace-match "")))))
+    ;; else
+    (let ((comment-start ";")
+          (comment-end "")
+          (comment-style 'plain))
+      (comment-region-default beg end arg))))
+
 (defun pygn-mode--get-or-create-board-buffer ()
   "Get or create the `pygn-mode' board buffer."
   (let ((buf (get-buffer-create pygn-mode-board-buffer-name)))
@@ -1182,10 +1204,15 @@ For use in `pygn-mode-ivy-jump-to-game-by-fen'."
 
   (setq-local comment-start "{")
   (setq-local comment-end "}")
-  (setq-local comment-continue " ")
   (setq-local comment-multi-line t)
-  (setq-local comment-style 'plain)
+  (setq-local comment-style 'multi-line)
   (setq-local comment-use-syntax t)
+  (setq-local comment-quote-nested nil)
+  ;; why does newcomment.el _force_ a non-whitespace comment-continue?
+  ;; comment-region-function must then be overridden to remove the
+  ;; continue character when not wanted.
+  (setq-local comment-continue "|")
+  (setq-local comment-region-function 'pygn-mode-comment-region-contextually)
   (setq-local parse-sexp-lookup-properties t)
   (setq-local parse-sexp-ignore-comments t)
 


### PR DESCRIPTION
With this PR, we get reliable integration with `newcomment.el`.  The `comment-region` command will always enclose the region with a single pair of curly brackets.
 * `comment-continue` characters will NOT be prepended to lines, though they are defined
 * nested comments will not be escaped.  `newcomment.el` supports that, but the PGN spec does not

~We can imagine an even nicer version of this function, which would comment lines with semicolons instead of curly brackets if the selected range was not within the movetext.~  Done.  Comment-region will comment with semicolons instead of curly braces whenever the region is not exclusively in the movetext portion of the PGN.
