### PR TITLE
Refer to melpa-stable in Cask file, for stability

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
 (source gnu)
-(source melpa)
+(source melpa-stable)
 
 (package-file "pygn-mode.el")

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,10 @@ TESTS=
 
 .PHONY : build autoloads test-autoloads test-tests test-prep test-batch test clean
 
-# todo restore line: (setq byte-compile-error-on-warn t)
-# after switching CI to melpa-stable
 build :
 	$(EMACS) $(EMACS_BATCH) --eval             \
 	    "(progn                                \
+	      (setq byte-compile-error-on-warn t)  \
 	      (batch-byte-compile))" *.el
 
 autoloads :


### PR DESCRIPTION
Instead of unstable `melpa`.
