### PR TITLE
Forgiving variant of pygn-mode-pgn-at-pos defun

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1194,9 +1194,11 @@ garbage."
           (forward-line 1))))
     (when-let ((move-node (pygn-mode--true-containing-node '(san_move lan_move))))
       (goto-char (pygn-mode--true-node-after-position move-node)))
-    (buffer-substring-no-properties
-     (pygn-mode-game-start-position)
-     (point))))
+    ;; todo returning nil might not be the best behavior when pos trails a game
+    (when-let ((start-pos (pygn-mode-game-start-position)))
+      (buffer-substring-no-properties
+       start-pos
+       (point)))))
 
 (defun pygn-mode-pgn-at-pos-as-if-variation (pos)
   "Return a single-game PGN string as if a variation had been played.

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1200,6 +1200,14 @@ garbage."
        start-pos
        (point)))))
 
+(defun pygn-mode--pgn-at-pos-or-stub (pos)
+  "Return a single-game PGN string inclusive of any move at POS.
+
+Identical to `pygn-mode-pgn-at-pos' except that a stub value is returned
+when POS is not inside a game."
+  (or (pygn-mode-pgn-at-pos pos)
+      "[Event \"?\"]\n\n*\n"))
+
 (defun pygn-mode-pgn-at-pos-as-if-variation (pos)
   "Return a single-game PGN string as if a variation had been played.
 
@@ -1779,7 +1787,7 @@ When called non-interactively, display the FEN corresponding to POS.
 With `prefix-arg' DO-COPY, copy the FEN to the kill ring, and to the system
 clipboard when running a GUI Emacs."
   (interactive "d\nP")
-  (let ((fen (pygn-mode-pgn-to-fen (pygn-mode-pgn-at-pos pos))))
+  (let ((fen (pygn-mode-pgn-to-fen (pygn-mode--pgn-at-pos-or-stub pos))))
     (when do-copy
       (kill-new fen)
       (when (and (fboundp 'gui-set-selection)
@@ -1798,7 +1806,7 @@ clipboard when running a GUI Emacs."
 
 When called non-interactively, display the FEN corresponding to POS."
   (interactive "d")
-  (let* ((fen (pygn-mode-pgn-to-fen (pygn-mode-pgn-at-pos pos)))
+  (let* ((fen (pygn-mode-pgn-to-fen (pygn-mode--pgn-at-pos-or-stub pos)))
          (buf (get-buffer-create pygn-mode-fen-buffer-name))
          (win (get-buffer-window buf)))
     (with-current-buffer buf
@@ -1829,7 +1837,7 @@ When called non-interactively, display the FEN corresponding to POS."
   "Save the board image corresponding to POS to a file."
   (let* ((pygn-mode-board-size (completing-read "Pixels per side: " nil nil nil nil nil pygn-mode-board-size))
          (filename (read-file-name "SVG filename: "))
-         (svg-data (pygn-mode-pgn-to-board (pygn-mode-pgn-at-pos pos) 'svg)))
+         (svg-data (pygn-mode-pgn-to-board (pygn-mode--pgn-at-pos-or-stub pos) 'svg)))
     (with-temp-buffer
       (insert svg-data)
       (write-file filename))))
@@ -1839,7 +1847,7 @@ When called non-interactively, display the FEN corresponding to POS."
 
 When called non-interactively, display the board corresponding to POS."
   (interactive "d")
-  (let* ((svg-data (pygn-mode-pgn-to-board (pygn-mode-pgn-at-pos pos) 'svg))
+  (let* ((svg-data (pygn-mode-pgn-to-board (pygn-mode--pgn-at-pos-or-stub pos) 'svg))
          (buf (pygn-mode--get-or-create-board-buffer))
          (win (get-buffer-window buf)))
     (with-current-buffer buf
@@ -1858,7 +1866,7 @@ When called non-interactively, display the board corresponding to POS."
 
 When called non-interactively, display the board corresponding to POS."
   (interactive "d")
-  (let* ((text-data (pygn-mode-pgn-to-board (pygn-mode-pgn-at-pos pos) 'text))
+  (let* ((text-data (pygn-mode-pgn-to-board (pygn-mode--pgn-at-pos-or-stub pos) 'text))
          (buf (pygn-mode--get-or-create-board-buffer))
          (win (get-buffer-window buf)))
     (with-current-buffer buf
@@ -1931,7 +1939,7 @@ When called non-interactively, display the board corresponding to POS."
 
 When called non-interactively, display the line corresponding to POS."
   (interactive "d")
-  (let* ((line (pygn-mode-pgn-to-line (pygn-mode-pgn-at-pos pos)))
+  (let* ((line (pygn-mode-pgn-to-line (pygn-mode--pgn-at-pos-or-stub pos)))
          (buf (get-buffer-create pygn-mode-line-buffer-name))
          (win (get-buffer-window buf)))
     (with-current-buffer buf


### PR DESCRIPTION
Here is one way to paper over the issues in #184 , and this might be good for a quick fix.

We make `pygn-mode-pgn-at-pos` return `nil` instead of ever throwing an exception.  This makes good sense — at least, the exception made no sense.

We introduce `pygn-mode--pgn-at-pos-or-stub`, a forgiving variant of the defun, which returns a stub value instead of nil (when the point is outside of a game).

Then the various interactive commands are made to use the forgiving `pygn-mode--pgn-at-pos-or-stub`, so that they don't throw exceptions depending on where the point is.  For example, if you try to echo FEN at point, and you are in between games, you will get the FEN for the default starting position.

Criticism: if every customer of the interface ends up using `pygn-mode--pgn-at-pos-or-stub`, then maybe the interface is not good.

Alternative: when the point is outside a game, return the preceding game.  I think this was the pre-tree-sitter behavior.  Not sure what is best when the point is _before_ any game.

Edit: for the alternative case, we already have `pygn-mode-game-start-position-forgive-trailing-pos`.