### PR TITLE
Port pygn-mode-pgn-at-pos-as-if-variation to tree-sitter

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1067,7 +1067,20 @@ POS defaults to the point."
   "Whether POS is inside a PGN variation.
 
 POS defaults to the point."
-  (pygn-mode--true-containing-node 'variation pos))
+  (save-excursion
+    ;; TODO: this is to cover up what is still buggy about tree-sitter-node-at-point
+    ;; and its wrapper pygn-mode--true-node-first-position.  When resting on
+    ;; whitespace, a parent variation node may not be returned, instead nil.
+    ;; The nil happens because an adjacent recursive variation spills over
+    ;; onto the whitespace occupied by the point.
+    (goto-char pos)
+    (when (pygn-mode--true-containing-node 'movetext)
+      (when (looking-at-p "\\s-")
+        (skip-syntax-backward "-")
+        (forward-char -1)
+        (when (looking-at-p ")")
+          (forward-char 1))))
+    (pygn-mode--true-containing-node 'variation)))
 
 (defun pygn-mode-inside-variation-or-comment-p (&optional pos)
   "Whether POS is inside a PGN comment or a variation.


### PR DESCRIPTION
 * adding support for recursive variations (!)
 * removing last regular-expression-based motion logic (!)
 * adding hack to make `pygn-mode-inside-variation-p` more precise on whitespace (pending a deeper fix to `pygn-mode--true-containing-node`)

`pygn-mode-looking-at-strict-legal-move` may well be added back in a different form if we need it.  But the strict/relaxed distinction does not need to be made anymore.