### PR TITLE
Bugfix: correct misuse of char-before as a coordinate

### DIFF
--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1104,7 +1104,8 @@ POS defaults to the point."
   (when-let ((annotation-node (pygn-mode--true-containing-node 'annotation)))
     (save-excursion
       (goto-char (pygn-mode--true-node-first-position annotation-node))
-      (when (pygn-mode--true-containing-node '(san_move lan_move) (char-before))
+      (ignore-errors (forward-char -1))
+      (when (pygn-mode--true-containing-node '(san_move lan_move))
         annotation-node))))
 
 (defun pygn-mode-looking-at-relaxed-legal-move ()
@@ -1156,7 +1157,8 @@ POS defaults to the point."
       ;; else
       (save-excursion
         (skip-syntax-backward "-")
-        (setq game-node (pygn-mode--true-containing-node 'game (char-before)))
+        (ignore-errors (forward-char -1))
+        (setq game-node (pygn-mode--true-containing-node 'game))
         (when game-node
           (pygn-mode--true-node-first-position game-node))))))
 

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1156,6 +1156,7 @@ POS defaults to the point."
         (pygn-mode--true-node-first-position game-node)
       ;; else
       (save-excursion
+        (goto-char (or pos (point)))
         (skip-syntax-backward "-")
         (ignore-errors (forward-char -1))
         (setq game-node (pygn-mode--true-containing-node 'game))


### PR DESCRIPTION
`char-before` returns a character, not a coordinate, and it was misused in #176 and elsewhere.