### PR TITLE
Enable pgn-at-pos test for point-min, with new value

### DIFF
--- a/ert-tests/pygn-mode-test.el
+++ b/ert-tests/pygn-mode-test.el
@@ -2010,12 +2010,12 @@
 
 ;;; pygn-mode-pgn-at-pos
 
-;; (ert-deftest pygn-mode-pgn-at-pos-01 nil
-;;   "Test `pygn-mode-pgn-at-pos' from the first position (a corner case)."
-;;   (pygn-mode-test-with-file "test-01.pgn"
-;;     (should (equal
-;;              "[Event \"?\"]\n"
-;;              (pygn-mode-pgn-at-pos (point-min))))))
+(ert-deftest pygn-mode-pgn-at-pos-01 nil
+  "Test `pygn-mode-pgn-at-pos' from the first position (a corner case)."
+  (pygn-mode-test-with-file "test-01.pgn"
+    (should (equal
+             "[Event \"?\"]\n[Site \"?\"]\n[Date \"????.??.??\"]\n[Round \"?\"]\n[White \"?\"]\n[Black \"?\"]\n[Result \"*\"]\n[SetUp \"1\"]\n[FEN \"r1bR2Q1/ppp3pp/4p1k1/2b1P1n1/1np1q3/5N2/PPP3PP/5R1K w - - 2 18\"]\n\n*\n"
+             (pygn-mode-pgn-at-pos (point-min))))))
 
 ;; TODO temporarily disabled
 ;;

--- a/ert-tests/pygn-mode-test.el
+++ b/ert-tests/pygn-mode-test.el
@@ -2017,6 +2017,8 @@
 ;;              "[Event \"?\"]\n"
 ;;              (pygn-mode-pgn-at-pos (point-min))))))
 
+;; TODO temporarily disabled
+;;
 ;; (ert-deftest pygn-mode-pgn-at-pos-02 nil
 ;;   "Test `pygn-mode-pgn-at-pos' string from every move-start position (test-01.pgn)."
 ;;   (pygn-mode-test-with-file "test-01.pgn"
@@ -2063,6 +2065,8 @@
                            fen-for-move)))
           (setq last-pos (1- move-pos)))))))
 
+;; TODO temporarily disabled
+;;
 ;; (ert-deftest pygn-mode-pgn-at-pos-05 nil
 ;;   "Test `pygn-mode-pgn-at-pos' string from every move-start position (test-02.pgn)."
 ;;   (pygn-mode-test-with-file "test-02.pgn"


### PR DESCRIPTION
This always was a corner case per the docstring.  What is the meaningful PGN at point-min?  The new code says it is the full set of header tagpairs; the old code said the first tagpair.  Both seem acceptable. Neither include any moves.

xref #208

cc @dekrueger 