### PR TITLE
Update versions/dates to v0.6.3, prep for release tag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2019-2021, Roland Walker, Dodge Coates
+Copyright (c) 2019-2024, Roland Walker, Dodge Coates
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ GNU Emacs 26.1+, compiled with dynamic module support
 
 [tree-sitter.el](https://github.com/emacs-tree-sitter/elisp-tree-sitter) and [tree-sitter-langs.el](https://github.com/emacs-tree-sitter/tree-sitter-langs)
 
-Python 3.7+
+Python 3.8+
 
-Needed for board images and FENs: [chess](https://pypi.org/project/chess/) (bundled version 1.9.4)
+Needed for board images and FENs: [chess](https://pypi.org/project/chess/) (bundled version 1.11.1)
 
 Needed for engine evaluations: [uci-mode](https://github.com/dwcoates/uci-mode)
 

--- a/pygn-mode.el
+++ b/pygn-mode.el
@@ -1,13 +1,13 @@
 ;;; pygn-mode.el --- Major-mode for chess PGN files, powered by Python -*- lexical-binding: t -*-
 
-;; Copyright (c) 2019-2023 Dodge Coates and Roland Walker
+;; Copyright (c) 2019-2024 Dodge Coates and Roland Walker
 
 ;; Author: Dodge Coates and Roland Walker
 ;; Homepage: https://github.com/dwcoates/pygn-mode
 ;; URL: https://raw.githubusercontent.com/dwcoates/pygn-mode/master/pygn-mode.el
-;; Version: 0.6.2
-;; Last-Updated: 01 Apr 2023
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.15.2") (tree-sitter-langs "0.10.7") (uci-mode "0.5.4") (nav-flash "1.0.0") (ivy "0.10.0"))
+;; Version: 0.6.3
+;; Last-Updated: 16 Dec 2024
+;; Package-Requires: ((emacs "26.1") (tree-sitter "0.15.2") (tree-sitter-langs "0.12.242") (uci-mode "0.5.4") (nav-flash "1.0.0") (ivy "0.10.0"))
 ;; Keywords: data, games, chess
 
 ;;; License
@@ -120,7 +120,7 @@
 
 ;;; Code:
 
-(defconst pygn-mode-version "0.6.2")
+(defconst pygn-mode-version "0.6.3")
 
 ;;; Imports
 
@@ -1596,12 +1596,12 @@ Intended for use in `post-command-hook'."
           "[ ] Bad. The executable '%s' is not a Python 3 interpreter.  Try installing Python 3.7+ and/or customizing the value of pygn-mode-python-executable.\n\n"
           pygn-mode-python-executable))
         (cl-return-from pygn-mode--run-diagnostic nil))
-      (if (zerop (call-process pygn-mode-python-executable nil nil nil "-c" "import sys; exit(0 if sys.hexversion >= 0x3070000 else 1)"))
-          (insert (format "[x] Good. The pygn-mode-python-executable at '%s' is better than or equal to Python version 3.7.\n\n" pygn-mode-python-executable))
+      (if (zerop (call-process pygn-mode-python-executable nil nil nil "-c" "import sys; exit(0 if sys.hexversion >= 0x3080000 else 1)"))
+          (insert (format "[x] Good. The pygn-mode-python-executable at '%s' is better than or equal to Python version 3.8.\n\n" pygn-mode-python-executable))
         ;; else
         (insert
          (format
-          "[ ] Bad. The executable '%s' is not at least Python version 3.7.  Try installing Python 3.7+ and/or customizing the value of pygn-mode-python-executable.\n\n"
+          "[ ] Bad. The executable '%s' is not at least Python version 3.8.  Try installing Python 3.8+ and/or customizing the value of pygn-mode-python-executable.\n\n"
           pygn-mode-python-executable))
         (cl-return-from pygn-mode--run-diagnostic nil))
       (if (zerop (call-process pygn-mode-python-executable nil nil nil "-c" "import chess"))

--- a/pygn_server.py
+++ b/pygn_server.py
@@ -19,7 +19,7 @@
 ### version
 ###
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 ###
 ### imports


### PR DESCRIPTION
 * update main version to 0.6.3
 * update copyright dates to 2024
 * update Python requirement to 3.8+ (required by the newest "chess" library)
 * document the bundled version of the "chess" library